### PR TITLE
Add JavaScript output to Travis CI build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ addons:
 env:
     - PROTOC_OUT=cpp
     - PROTOC_OUT=python
+before_script:
+    - protoc --version
 script:
     - mkdir -p "build/${PROTOC_OUT}"
     - protoc "--${PROTOC_OUT}_out=build/${PROTOC_OUT}" schemas/*.proto

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 dist: trusty
 sudo: false
 language: generic
-addons:
-    apt:
-        packages:
-            - protobuf-compiler
 env:
     - PROTOC_OUT=cpp
     - PROTOC_OUT=python
+install:
+    - export PROTOC_VERSION='3.2.0'
+    - curl -sSLO "https://github.com/google/protobuf/releases/download/v3.2.0/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+    - mkdir protoc
+    - unzip -d protoc "protoc-${PROTOC_VERSION}-linux-x86_64.zip"
+    - export PATH="${PATH}:${PWD}/protoc/bin"
 before_script:
     - protoc --version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ install:
 before_script:
     - protoc --version
 script:
-    - mkdir -p "build/${PROTOC_OUT}"
-    - protoc "--${PROTOC_OUT}_out=build/${PROTOC_OUT}" schemas/*.proto
+    - protoc "--${PROTOC_OUT}_out=${PROTOC_OUT_OPTIONS}./" schemas/*.proto
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: generic
 env:
     - PROTOC_OUT=cpp
+    - PROTOC_OUT=js PROTOC_OUT_OPTIONS="import_style=commonjs,binary:"
     - PROTOC_OUT=python
 install:
     - export PROTOC_VERSION='3.2.0'

--- a/schemas/.gitignore
+++ b/schemas/.gitignore
@@ -1,0 +1,4 @@
+*
+!*.proto
+!.gitignore
+!.npmignore


### PR DESCRIPTION
This PR adds a Travis CI build matrix for the JavaScript output of the schemas. I've updated the compiler (protoc) version to 3.2.0 to make everything work.