### PR TITLE
Add schemas for Rev 1.3

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 messages = [
+    'Bytes',
     'Gps',
     'Motion',
     'Position',
+    'TypedMessage',
     'Velocity',
 ];
 module.exports = Object.assign({}, null);

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ messages = [
     'Bytes',
     'ControlMode',
     'Gps',
+    'MissionInformation',
     'Motion',
     'Position',
     'TypedMessage',

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ messages = [
     'Position',
     'TypedMessage',
     'Velocity',
+    'Waypoint',
 ];
 module.exports = Object.assign({}, null);
 messages.forEach((name) =>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 messages = [
     'Bytes',
+    'ControlMode',
     'Gps',
     'Motion',
     'Position',

--- a/schemas/Bytes.proto
+++ b/schemas/Bytes.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "BytesProtobuf";
+
+message Bytes {
+    required int32 byte_count = 1;
+    required bytes bytes = 2;
+}

--- a/schemas/ControlMode.proto
+++ b/schemas/ControlMode.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "ControlModeProtobuf";
+
+message ControlMode {
+    enum Mode {
+        MANUAL = 0;
+        WAYPOINT = 1;
+    }
+    required Mode mode = 1;
+}

--- a/schemas/MissionInformation.proto
+++ b/schemas/MissionInformation.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "MissionInformationProtobuf";
+
+message MissionInformation {
+    required double distance_to_waypoint = 1;
+}

--- a/schemas/TypedMessage.proto
+++ b/schemas/TypedMessage.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 option java_package = "schemas";
 option java_outer_classname = "TypedMessageProtobuf";
 
+import "schemas/ControlMode.proto";
 import "schemas/Gps.proto";
 import "schemas/Motion.proto";
 
@@ -10,6 +11,7 @@ message TypedMessage {
     enum Type {
         GPS = 1;
         MOTION = 2;
+        CONTROL_MODE = 3;
     }
 
     required Type type = 1;
@@ -17,4 +19,5 @@ message TypedMessage {
 
     optional Gps gps = 10;
     optional Motion motion = 11;
+    optional ControlMode control_mode = 12;
 }

--- a/schemas/TypedMessage.proto
+++ b/schemas/TypedMessage.proto
@@ -1,0 +1,20 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "TypedMessageProtobuf";
+
+import "schemas/Gps.proto";
+import "schemas/Motion.proto";
+
+message TypedMessage {
+    enum Type {
+        GPS = 1;
+        MOTION = 2;
+    }
+
+    required Type type = 1;
+    extensions 2 to 9;
+
+    optional Gps gps = 10;
+    optional Motion motion = 11;
+}

--- a/schemas/TypedMessage.proto
+++ b/schemas/TypedMessage.proto
@@ -5,6 +5,7 @@ option java_outer_classname = "TypedMessageProtobuf";
 
 import "schemas/ControlMode.proto";
 import "schemas/Gps.proto";
+import "schemas/MissionInformation.proto";
 import "schemas/Motion.proto";
 import "schemas/Waypoint.proto";
 
@@ -14,6 +15,7 @@ message TypedMessage {
         MOTION = 2;
         CONTROL_MODE = 3;
         WAYPOINT = 4;
+        MISSION_INFORMATION = 5;
     }
 
     required Type type = 1;
@@ -23,4 +25,5 @@ message TypedMessage {
     optional Motion motion = 11;
     optional ControlMode control_mode = 12;
     optional Waypoint waypoint = 13;
+    optional MissionInformation mission_information = 14;
 }

--- a/schemas/TypedMessage.proto
+++ b/schemas/TypedMessage.proto
@@ -6,12 +6,14 @@ option java_outer_classname = "TypedMessageProtobuf";
 import "schemas/ControlMode.proto";
 import "schemas/Gps.proto";
 import "schemas/Motion.proto";
+import "schemas/Waypoint.proto";
 
 message TypedMessage {
     enum Type {
         GPS = 1;
         MOTION = 2;
         CONTROL_MODE = 3;
+        WAYPOINT = 4;
     }
 
     required Type type = 1;
@@ -20,4 +22,5 @@ message TypedMessage {
     optional Gps gps = 10;
     optional Motion motion = 11;
     optional ControlMode control_mode = 12;
+    optional Waypoint waypoint = 13;
 }

--- a/schemas/Waypoint.proto
+++ b/schemas/Waypoint.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "WaypointProtobuf";
+
+message Waypoint {
+    required double longitude = 1;
+    required double latitude = 2;
+    optional double elevation = 3;
+}


### PR DESCRIPTION
This PR adds the schemas needed for Rev 1.3.

New schemas:

- [x] `TypedMessage` (closes #9)
- [x] `Bytes`
- [x] `ControlMode` (closes #10)
- [x] `Waypoint` (closes #12)
- [x] `MissionInformation`