### PR TITLE
Add gains and config schemas

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ messages = [
     'Gps',
     'MissionInformation',
     'Motion',
+    'PidControllerGains',
     'Position',
     'TypedMessage',
     'Velocity',

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 messages = [
+    'BoatConfig',
     'Bytes',
     'ControlMode',
     'Gps',

--- a/schemas/BoatConfig.proto
+++ b/schemas/BoatConfig.proto
@@ -1,0 +1,13 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "WaypointProtobuf";
+
+import "schemas/PidControllerGains.proto";
+
+message BoatConfig {
+    required PidControllerGains surge_controller_gains = 1;
+    required double surge_controller_dt = 2;
+    required PidControllerGains yaw_controller_gains = 3;
+    required double yaw_controller_dt = 4;
+}

--- a/schemas/PidControllerGains.proto
+++ b/schemas/PidControllerGains.proto
@@ -1,0 +1,10 @@
+syntax = "proto2";
+
+option java_package = "schemas";
+option java_outer_classname = "PidControllerGainsProtobuf";
+
+message PidControllerGains {
+    required double kp = 1;
+    required double ki = 2;
+    required double kd = 3;
+}

--- a/schemas/TypedMessage.proto
+++ b/schemas/TypedMessage.proto
@@ -3,6 +3,7 @@ syntax = "proto2";
 option java_package = "schemas";
 option java_outer_classname = "TypedMessageProtobuf";
 
+import "schemas/BoatConfig.proto";
 import "schemas/ControlMode.proto";
 import "schemas/Gps.proto";
 import "schemas/MissionInformation.proto";
@@ -16,6 +17,7 @@ message TypedMessage {
         CONTROL_MODE = 3;
         WAYPOINT = 4;
         MISSION_INFORMATION = 5;
+        BOAT_CONFIG = 6;
     }
 
     required Type type = 1;
@@ -26,4 +28,5 @@ message TypedMessage {
     optional ControlMode control_mode = 12;
     optional Waypoint waypoint = 13;
     optional MissionInformation mission_information = 14;
+    optional BoatConfig boat_config = 15;
 }


### PR DESCRIPTION
This PR adds the following message schemas:

- [x] `PidControllerGains`—holds the gains for a single PID controller
- [x] `BoatConfig`—holds the surge and yaw PID controller settings