### PR TITLE
Add tools to build TypeScript definitions for the JS output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto
+build/* linguist-vendored
 index.js linguist-vendored

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+*.d.ts
+*.js
 *.tgz
 node_modules/

--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,14 @@
+*.js
+*.d.ts
 *.tgz
 .editorconfig
 .gitattributes
 .gitignore
 .npmignore
 .travis.yml
+!closure.lib.d.ts
+!index.js
+!index.d.ts
+!protos.d.ts
+build/
 node_modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ env:
     - PROTOC_OUT=js PROTOC_OUT_OPTIONS="import_style=commonjs,binary:"
     - PROTOC_OUT=python
     - PROTOC_OUT=objc
+before_install:
+    - export GRADLE_VERSION='4.3.1'
+    - export GRADLE_DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
+    - export TERM=dumb
+    - ( cd $HOME && curl -LO "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" )
+    - ( cd $HOME && unzip -q gradle-$GRADLE_VERSION-bin.zip && rm gradle-$GRADLE_VERSION-bin.zip )
+    - export PATH=$HOME/gradle-$GRADLE_VERSION/bin:$PATH && hash -r && gradle --version
 install:
     - export PROTOC_VERSION='3.3.0'
     - curl -sSLO "https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,27 @@
 </p>
 <h1 align="center">Message Schemas</h1>
 
-This repository contains the Protocol Buffer schemas for the messages used by Lake Maps' boat control software and Hangashore applications.
-
 This is a work in progress.
+
+This repository contains the Protocol Buffer schemas for the messages used by Lake Maps' boat control software and Hangashore applications. The schemas here can be used to generate source code in a number of different languages (see https://developers.google.com/protocol-buffers/ for more information).
+
+## JavaScript
+
+The JavaScript output of `protoc` is published on npm as a CommonJS module:
+
+```bash
+$ npm install @lakemaps/schemas
+```
+
+### TypeScript
+
+The `@lakemaps/schemas` package includes TypeScript definitions created using [Angular's Clutz project][clutz].
+
+To build the TypeScript definitions from source:
+
+```bash
+$ build/buildscript
+$ npm run build
+```
+
+  [clutz]:https://github.com/angular/clutz

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,4 @@
+clutz/
+closure-compiler/
+closure-library/
+protobuf/

--- a/build/buildscript
+++ b/build/buildscript
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+cd "$(npm prefix)/build/"
+
+clone-gh-project() {
+    local -r key="${1}"
+    local -r dir="$(basename "${key}")"
+
+    if [[ -d "${dir}/.git/" ]]
+    then
+        return
+    fi
+
+    git clone --depth=1 "https://github.com/${key}" "${dir}"
+}
+
+# Dependencies
+clone-gh-project "whymarrh/clutz"
+clone-gh-project "google/closure-compiler"
+clone-gh-project "google/closure-library"
+clone-gh-project "google/protobuf"
+
+# Build Clutz
+(cd clutz/ && gradle --no-daemon installDist)
+
+# We need the compile against the Closure libs to resolve
+# some of the types Clutz uses in the declaration files,
+# so we'll move this out of the build directory for `npm pack`
+cp clutz/src/resources/closure.lib.d.ts ../
+
+# Produce protos.js
+npm run buildClosureLibrary
+
+# Run Clutz
+clutz/build/install/clutz/bin/clutz ../protos.js -o ../protos.d.ts \
+    --externs \
+        closure-compiler/externs/es3.js \
+        closure-compiler/externs/es5.js \
+        closure-compiler/externs/es6.js \
+        closure-library/closure/goog/base.js \
+        closure-library/closure/goog/array/array.js \
+        closure-library/closure/goog/asserts/asserts.js \
+        closure-library/closure/goog/crypt/base64.js \
+        closure-library/closure/goog/debug/error.js \
+        closure-library/closure/goog/dom/nodetype.js \
+        closure-library/closure/goog/labs/useragent/browser.js \
+        closure-library/closure/goog/labs/useragent/engine.js \
+        closure-library/closure/goog/labs/useragent/platform.js \
+        closure-library/closure/goog/labs/useragent/util.js \
+        closure-library/closure/goog/object/object.js \
+        closure-library/closure/goog/reflect/reflect.js \
+        closure-library/closure/goog/string/string.js \
+        closure-library/closure/goog/useragent/product.js \
+        closure-library/closure/goog/useragent/useragent.js \
+        protobuf/js/map.js \
+        protobuf/js/message.js \
+        protobuf/js/binary/arith.js \
+        protobuf/js/binary/constants.js \
+        protobuf/js/binary/decoder.js \
+        protobuf/js/binary/encoder.js \
+        protobuf/js/binary/reader.js \
+        protobuf/js/binary/utils.js \
+        protobuf/js/binary/writer.js \
+    --skipEmitRegExp \
+        '(?:closure-.*)|(?:protobuf.*)'

--- a/build/buildscript
+++ b/build/buildscript
@@ -19,7 +19,7 @@ clone-gh-project() {
 }
 
 # Dependencies
-clone-gh-project "whymarrh/clutz"
+clone-gh-project "angular/clutz"
 clone-gh-project "google/closure-compiler"
 clone-gh-project "google/closure-library"
 clone-gh-project "google/protobuf"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+/// <reference path="closure.lib.d.ts" />
+/// <reference path="protos.d.ts" />
+declare module '@lakemaps/schemas' {
+  export = ಠ_ಠ.clutz.proto;
+}

--- a/index.js
+++ b/index.js
@@ -1,16 +1,6 @@
-messages = [
-    'BoatConfig',
-    'Bytes',
-    'ControlMode',
-    'Gps',
-    'MissionInformation',
-    'Motion',
-    'PidControllerGains',
-    'Position',
-    'TypedMessage',
-    'Velocity',
-    'Waypoint',
-];
-module.exports = Object.assign({}, null);
-messages.forEach((name) =>
-    module.exports[name] = require(`./schemas/${name}_pb`)[name]);
+const path = require('path');
+module.exports = new Proxy({}, {
+    get(target, name) {
+        return require(path.resolve(__dirname, `./schemas/${name}_pb.js`))[name];
+    }
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "buildClosureLibrary": "protoc --js_out='library=protos,binary:./' schemas/*.proto",
     "build": "protoc --js_out='import_style=commonjs,binary:./' schemas/*.proto",
-    "prepublishOnly": "npm run build"
+    "prepublishOnly": "build/buildscript && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "OSL-3.0",
   "version": "3.3.1",
   "scripts": {
+    "buildClosureLibrary": "protoc --js_out='library=protos,binary:./' schemas/*.proto",
     "build": "protoc --js_out='import_style=commonjs,binary:./' schemas/*.proto",
     "prepublishOnly": "npm run build"
   },


### PR DESCRIPTION
This PR adds the tools to build TypeScript definitions for the JavaScript Protobuf output using [Clutz](https://github.com/angular/clutz). I've added Gradle to the Travis CI config in preparation for building the defns there and having the package published from CI.

Tasks:

- [x] Document the build process in `README.md`