### PR TITLE
Move all CI env vars into env block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,21 @@ dist: trusty
 sudo: false
 language: generic
 env:
-    - PROTOC_OUT=cpp
-    - PROTOC_OUT=js PROTOC_OUT_OPTIONS="import_style=commonjs,binary:"
-    - PROTOC_OUT=python
-    - PROTOC_OUT=objc
+    global:
+        - PROTOC_VERSION='3.3.0'
+        - GRADLE_VERSION='4.3.1'
+        - GRADLE_DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
+        - TERM=dumb
+    matrix:
+        - PROTOC_OUT=cpp
+        - PROTOC_OUT=js PROTOC_OUT_OPTIONS="import_style=commonjs,binary:"
+        - PROTOC_OUT=python
+        - PROTOC_OUT=objc
 before_install:
-    - export GRADLE_VERSION='4.3.1'
-    - export GRADLE_DISTRIBUTION_URL="https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip"
-    - export TERM=dumb
     - ( cd $HOME && curl -LO "https://services.gradle.org/distributions/gradle-$GRADLE_VERSION-bin.zip" )
     - ( cd $HOME && unzip -q gradle-$GRADLE_VERSION-bin.zip && rm gradle-$GRADLE_VERSION-bin.zip )
     - export PATH=$HOME/gradle-$GRADLE_VERSION/bin:$PATH && hash -r && gradle --version
 install:
-    - export PROTOC_VERSION='3.3.0'
     - curl -sSLO "https://github.com/google/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip"
     - mkdir protoc
     - unzip -d protoc "protoc-${PROTOC_VERSION}-linux-x86_64.zip"


### PR DESCRIPTION
This PR cleans up the CI config a bit by moving the the environment variables into the `env` block